### PR TITLE
chore: use modern sha3 instead of rust-crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 [dependencies]
 petgraph = "0.6"
 hex = "0.4"
-rust-crypto = "0.2"
-
+sha3 = "0.10"
+digest = "0.10"
 
 
 [lib]

--- a/src/graph/visualizer.rs
+++ b/src/graph/visualizer.rs
@@ -38,7 +38,7 @@ pub fn graphviz(tree: &MerkleTree) -> std::io::Result<()> {
     fs::write(dot_file, dot).expect("Unable to write to file");
     let output_directory = "./output";
     if !fs::metadata(output_directory).is_ok() {
-        fs::create_dir_all(output_directory.clone()).expect("Failed to create directory");
+        fs::create_dir_all(output_directory).expect("Failed to create directory");
     }
     let current_dir = env::current_dir()?;
     let output_path = current_dir.join("output/merkle_tree.png");

--- a/src/utils/keccak.rs
+++ b/src/utils/keccak.rs
@@ -11,7 +11,7 @@
 //!  ```
 
 use crate::utils::errors::BytesError;
-use crypto::{digest::Digest, sha3::Sha3};
+use sha3::{Digest, Keccak256};
 
 /// Computes the Keccak256 hash of the given input.
 ///
@@ -42,10 +42,9 @@ pub fn keccak256(input: &str) -> Result<String, BytesError> {
             return Err(BytesError::KeccakError(value));
         }
     };
-    let mut hasher = Sha3::keccak256();
-    hasher.input(&*hash);
-    let mut result = [0u8; 32];
-    hasher.result(&mut result);
+    let mut hasher = Keccak256::new();
+    hasher.update(&*hash);
+    let result = hasher.finalize();
     let hex_string: Vec<String> = result.iter().map(|b| format!("{:02x}", b)).collect();
     Ok(hex_string.concat())
 }


### PR DESCRIPTION
- Replace unmaintained `rust-crypto` with its modern replacement, `sha3`
- Fix a clippy issue